### PR TITLE
Add enableJwtScopeAsArray config for resident IDP OIDC properties

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/util/IdentityApplicationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2014-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -260,6 +260,8 @@ public class IdentityApplicationConstants {
             public static final String IS_PKCE_ENABLED = "IsPKCEEnabled";
             public static final Object IS_PKCE_ENABLED_PARAM_NAME = "oidcPKCEEnabled";
             public static final String PRESERVE_SESSION_AT_PASSWORD_UPDATE = "preserveSessionAtPasswordUpdate";
+            public static final String ENABLE_JWT_SCOPE_AS_ARRAY = "enableJwtScopeAsArray";
+            public static final String ENABLE_JWT_SCOPE_AS_ARRAY_DEFAULT = "false";
 
         }
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/IdentityProviderManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2014-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -260,7 +260,19 @@ public class IdentityProviderManager implements IdpManager {
             oidcProperty.setValue(getOIDCResidentIdPEntityId());
 
             FederatedAuthenticatorConfig oidcAuthenticationConfig = new FederatedAuthenticatorConfig();
-            oidcAuthenticationConfig.setProperties(new Property[]{oidcProperty});
+            List<Property> oidcProperties = new ArrayList<>();
+            oidcProperties.add(oidcProperty);
+
+            if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                Property jwtScopeAsArrayProp = new Property();
+                jwtScopeAsArrayProp.setName(
+                        IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY);
+                jwtScopeAsArrayProp.setValue(
+                        IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY_DEFAULT);
+                oidcProperties.add(jwtScopeAsArrayProp);
+            }
+
+            oidcAuthenticationConfig.setProperties(oidcProperties.toArray(new Property[0]));
             oidcAuthenticationConfig.setName(IdentityApplicationConstants.Authenticator.OIDC.NAME);
             oidcAuthenticationConfig.setDefinedByType(DefinedByType.SYSTEM);
 

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/dao/IdPManagementDAO.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2014-2025 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2026, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -3096,6 +3096,17 @@ public class IdPManagementDAO {
             preserveSessionAtPwUpdate.setValue(preserveLoggedInSessionAtPwUpdate);
         }
         propertiesList.add(preserveSessionAtPwUpdate);
+
+        Property jwtScopeAsArrayProp = IdentityApplicationManagementUtil.getProperty(oidcFedAuthn.getProperties(),
+                IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY);
+        if (jwtScopeAsArrayProp == null) {
+            jwtScopeAsArrayProp = new Property();
+            jwtScopeAsArrayProp.setName(
+                    IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY);
+            jwtScopeAsArrayProp.setValue(
+                    IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY_DEFAULT);
+        }
+        propertiesList.add(jwtScopeAsArrayProp);
 
         oidcFedAuthn.setProperties(propertiesList.toArray(new Property[0]));
         fedAuthnConfigs.add(oidcFedAuthn);

--- a/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
+++ b/components/idp-mgt/org.wso2.carbon.idp.mgt/src/main/java/org/wso2/carbon/idp/mgt/util/IdPManagementConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2014-2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -162,7 +162,8 @@ public class IdPManagementConstants {
     public static final String SMS_USERNAME_RECOVERY_PROPERTY = "Recovery.Notification.Username.SMS.Enable";
 
     public static final List<String> INHERITED_FEDERATED_AUTHENTICATORS = List.of(
-            IdentityApplicationConstants.Authenticator.SAML2SSO.NAME);
+            IdentityApplicationConstants.Authenticator.SAML2SSO.NAME,
+            IdentityApplicationConstants.Authenticator.OIDC.NAME);
 
     // Constants related to inheriting login & registration configurations.
     public static final String PASSWORD_EXPIRY_RULES_KEY_PREFIX = "passwordExpiry.rule";
@@ -170,7 +171,8 @@ public class IdPManagementConstants {
     public static final List<String> INHERITED_FEDERATED_AUTHENTICATOR_PROPERTIES = List.of(
             IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_SIGNING_ENABLED,
             IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_VALIDITY_PERIOD,
-            IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED);
+            IdentityApplicationConstants.Authenticator.SAML2SSO.SAML_METADATA_AUTHN_REQUESTS_SIGNING_ENABLED,
+            IdentityApplicationConstants.Authenticator.OIDC.ENABLE_JWT_SCOPE_AS_ARRAY);
 
     public static final List<String> INHERITANCE_DISABLED_GOVERNANCE_PROPERTIES = List.of(
             "Organization.SelfService.Enable",


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request introduces support for a new resident IDP OIDC property, `enableJwtScopeAsArray`. The property is now included by default in resident IdP configurations (except for organizations), and is handled with property inheritance for sub-organizations.
